### PR TITLE
Add proxy and endpoint customization support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -27,3 +27,4 @@ COPY --from=build /go/src/github.com/webdevops/public-holiday-exporter/public-ho
 RUN chown -R 1000:1000 /app
 USER 1000
 ENTRYPOINT /entrypoint.sh
+EXPOSE 8080

--- a/Dockerfile
+++ b/Dockerfile
@@ -18,8 +18,12 @@ RUN ./public-holiday-exporter --help
 #############################################
 # FINAL IMAGE
 #############################################
-FROM gcr.io/distroless/static
+FROM alpine:3.12
 ENV LOG_JSON=1
-COPY --from=build /go/src/github.com/webdevops/public-holiday-exporter/public-holiday-exporter /
+RUN apk add bash tzdata
+COPY ./docker/entrypoint.sh /entrypoint.sh
+RUN mkdir /app 
+COPY --from=build /go/src/github.com/webdevops/public-holiday-exporter/public-holiday-exporter /app/
+RUN chown -R 1000:1000 /app
 USER 1000
-ENTRYPOINT ["/public-holiday-exporter"]
+ENTRYPOINT /entrypoint.sh

--- a/Makefile
+++ b/Makefile
@@ -42,4 +42,4 @@ lint: $(GOLANGCI_LINT_BIN)
 dependencies: $(GOLANGCI_LINT_BIN)
 
 $(GOLANGCI_LINT_BIN):
-	curl -sfL https://install.goreleaser.com/github.com/golangci/golangci-lint.sh | sh -s -- -b $(FIRST_GOPATH)/bin v1.32.2
+	curl -sfL https://install.goreleaser.com/github.com/golangci/golangci-lint.sh | sh -s -- -b $(FIRST_GOPATH)/bin v1.35.2

--- a/config.go
+++ b/config.go
@@ -9,6 +9,8 @@ import (
 type (
 	Config struct {
 		Countries []ConfigCountry `yaml:"countries"`
+		Proxy     *string         `yaml:"proxy,omitempty"`
+		Endpoint  *string         `yaml:"endpoint,omitempty"`
 	}
 
 	ConfigCountry struct {
@@ -18,19 +20,19 @@ type (
 )
 
 func NewAppConfig(path string) (config Config) {
-	var filecontent []byte
+	var fileContent []byte
 
 	config = Config{}
 
 	log.Infof("reading configuration from file %v", path)
 	if data, err := ioutil.ReadFile(path); err == nil {
-		filecontent = data
+		fileContent = data
 	} else {
 		panic(err)
 	}
 
 	log.Info("parsing configuration")
-	if err := yaml.Unmarshal(filecontent, &config); err != nil {
+	if err := yaml.Unmarshal(fileContent, &config); err != nil {
 		panic(err)
 	}
 

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -1,0 +1,35 @@
+#!/bin/bash
+
+# Config example:
+#
+# COUNTRY_TZ="DE,Europe/Berlin CH,Europe/Zurich"
+# PROXY_ADDR="proxy:3128"
+# ENDPOINT="https://my-endpoint:8080"
+
+function add_config(){
+    echo -e "$@" >> /tmp/config.yaml
+}
+
+add_config "countries:"
+for i in $COUNTRY_TZ; do
+    IFS=","
+    key="- country"
+    for j in $i; do
+        add_config "$key: \"$j\""
+        key="  timezone"
+    done
+    add_config
+    IFS=" "
+done
+
+if [ -n "$PROXY_ADDR" ]; then
+    add_config "proxy: \"$PROXY_ADDR\""
+fi
+
+if [ -n "$ENDPOINT" ]; then
+    add_config "endpoint: \"$ENDPOINT\""
+fi
+
+mv /tmp/config.yaml /app/config.yaml
+
+/app/public-holiday-exporter -c /app/config.yaml

--- a/example.yaml
+++ b/example.yaml
@@ -1,6 +1,8 @@
 countries:
   - country: "DE"
     timezone: "Europe/Berlin"
+  - country: "CH"
+    timezone: "Europe/Zurich"
   - country: "FR"
     timezone: "Europe/Paris"
   - country: "GB"
@@ -8,3 +10,5 @@ countries:
   - country: "NZ"
     timezone: "Pacific/Auckland"
 
+# proxy: http://my-proxy:8080
+endpoint: http://127.0.0.1:80

--- a/main.go
+++ b/main.go
@@ -28,15 +28,15 @@ var (
 var opts config.Opts
 
 func main() {
-	initArgparser()
+	initArgParser()
 
 	log.Infof("starting public-holiday-exporter v%s (%s; %s; by %v)", gitTag, gitCommit, runtime.Version(), Author)
 	log.Info(string(opts.GetJson()))
 
-	config := NewAppConfig(opts.ConfigPath)
+	appConfig := NewAppConfig(opts.ConfigPath)
+	collector := NewMetricCollector(&appConfig)
 
-	collector := NewMetricCollector()
-	for _, line := range config.Countries {
+	for _, line := range appConfig.Countries {
 		log.Infof("adding country %v with timezone %v", line.Country, line.Timezone)
 		collector.AddCountry(line.Country, line.Timezone)
 	}
@@ -68,7 +68,7 @@ func main() {
 
 // init argparser and parse/validate arguments
 
-func initArgparser() {
+func initArgParser() {
 	argparser = flags.NewParser(&opts, flags.Default)
 	_, err := argparser.Parse()
 


### PR DESCRIPTION
As per title, this PR adds the support for a custom proxy and a custom endpoint.
This is useful because the nager/Nager.Date project specifically says:
> If you need more as 50 requests per day please use your own private api (docker).

Since we're making by default 0.5 requests per hour, we're just below 50 requests per day threshold.

This PR contains:
- Code Refactoring
- Proxy support via config.yaml entry
- Endpoint customization via config.yaml